### PR TITLE
Add example of Double-Submit CSRF configuration

### DIFF
--- a/src/main/java/example/cashcard/SecurityConfig.java
+++ b/src/main/java/example/cashcard/SecurityConfig.java
@@ -1,10 +1,15 @@
 package example.cashcard;
 
+import java.io.IOException;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
@@ -12,6 +17,12 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
+import org.springframework.security.web.csrf.CsrfFilter;
+import org.springframework.security.web.csrf.CsrfToken;
+import org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler;
+import org.springframework.security.web.csrf.HttpSessionCsrfTokenRepository;
+import org.springframework.web.filter.OncePerRequestFilter;
 
 @Configuration
 @EnableWebSecurity
@@ -20,11 +31,27 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http.authorizeHttpRequests()
-                .requestMatchers("/cashcards/**")
-                .hasRole("CARD-OWNER")
-                .and()
-                .csrf().disable()
-                .httpBasic()
+                    .requestMatchers("/cashcards/**")
+                    .hasRole("CARD-OWNER")
+                    .and()
+                .csrf()
+                    .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
+                    .csrfTokenRequestHandler(new CsrfTokenRequestAttributeHandler())
+                    .and()
+                .httpBasic().and()
+                // In case you do want to read the cookie value from the SPA, you need to actually generate the csrf
+                // token and put it in a cookie.
+                // The token is only generated when accessed, so this filter access the token value and does nothing
+                // nothing else, resulting the cookie being written to the response.
+//                .addFilterAfter(new OncePerRequestFilter() {
+//                    @Override
+//                    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+//                        // The CSRF cookie is only written when accessed. Force the cookie to be written by accessing it.
+//                        CsrfToken token = (CsrfToken) request.getAttribute(CsrfToken.class.getName());
+//                        token.getToken();
+//                        filterChain.doFilter(request, response);
+//                    }
+//                }, CsrfFilter.class)
         ;
         return http.build();
     }


### PR DESCRIPTION
This PR showcases how to implement double-submit CSRF, with two ways of setting the token value in the tests.

[Spring-Sec reference on CSRF](https://docs.spring.io/spring-security/reference/servlet/exploits/csrf.html#servlet-csrf-configure)